### PR TITLE
Allow a specific configured program call to start languagetool:

### DIFF
--- a/doc/LanguageTool.txt
+++ b/doc/LanguageTool.txt
@@ -171,6 +171,18 @@ g:languagetool_jar                                       *g:languagetool_jar*
 
   :let g:languagetool_jar='$HOME/languagetool/languagetool-standalone/target/LanguageTool-4.3-SNAPSHOT/LanguageTool-4.3-SNAPSHOT/languagetool-commandline.jar'
 
+g:languagetool_cmd                                       *g:languagetool_cmd*
+
+  Conversely, you could use this variable to specify by yourself the
+  command call. This variable take priority over g:languagetool_jar.
+  This is usefull for system package management installs like for
+  archlinux.
+
+  Example: >
+
+  :let g:languagetool_cmd='/usr/bin/languagetool'
+  :let g:languagetool_cmd='java -jar $HOME/languagetool/languagetool-standalone/target/LanguageTool-4.3-SNAPSHOT/LanguageTool-4.3-SNAPSHOT/languagetool-commandline.jar'
+
 g:languagetool_lang                                      *g:languagetool_lang*
 
   The language code to use for the language tool checker. If undefined,

--- a/plugin/LanguageTool.vim
+++ b/plugin/LanguageTool.vim
@@ -176,7 +176,7 @@ function s:LanguageToolSetUp() "{{{1
   \ ? g:languagetool_jar
   \ : $HOME . '/languagetool/languagetool-commandline.jar'
 
-  if !filereadable(s:languagetool_jar)
+  if !exists("g:languagetool_cmd") && !filereadable(s:languagetool_jar)
     " Hmmm, can't find the jar file.  Try again with expand() in case user
     " set it up as: let g:languagetool_jar = '$HOME/languagetool-commandline.jar'
     let l:languagetool_jar = expand(s:languagetool_jar)
@@ -253,8 +253,11 @@ function s:LanguageToolCheck(line1, line2) "{{{1
   let l:range = a:line1 . ',' . a:line2
   silent exe l:range . 'w!' . l:tmpfilename
 
-  let l:languagetool_cmd = 'java'
-  \ . ' -jar '  . s:languagetool_jar
+  let l:languagetool_cmd = exists("g:languagetool_cmd")
+  \ ? g:languagetool_cmd
+  \ : 'java -jar ' . s:languagetool_jar
+
+  let l:languagetool_cmd = l:languagetool_cmd
   \ . ' -c '    . s:languagetool_encoding
   \ . (empty(s:languagetool_disable_rules) ? '' : ' -d '.s:languagetool_disable_rules)
   \ . (empty(s:languagetool_enable_rules) ?  '' : ' -e '.s:languagetool_enable_rules)


### PR DESCRIPTION
On my distribution, archlinux, the pacman manager allow to install
languagetool. The package provide an unified script to start
languagetool command, server and gui. This update allow to use
vim-languagetool without using the jar file directly.