### PR TITLE
Updated desktop/standalone server download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To use this plugin, you need to install the Java LanguageTool grammar
 checker. You can chose to:
 
 * Download the stand-alone version of
-  LanguageTool(LanguageTool-\*.zip) from
+  LanguageTool(LanguageTool-stable.zip) from
   [here](https://dev.languagetool.org/http-server.html) using the 
   first link labeled "Getting the server" at the top of the page.
 
@@ -104,13 +104,13 @@ Recent versions of LanguageTool require Java-8.
 
 ## Download the stand-alone version of LanguageTool
 
-Download the stand-alone version of LanguageTool (LanguageTool-*.zip)
+Download the stand-alone version of LanguageTool (LanguageTool-stable.zip)
 from https://dev.languagetool.org/http-server.html, scroll down and click on
-"Desktop version for offline use" to download it. Unzip it:
+"LanguageTool Desktop version for offline use". Unzip it:
 ```
-  $ unzip LanguageTool-4.9.zip
+  $ unzip LanguageTool-stable.zip
 ```
-This should extract the file LanguageTool-4.9/languagetool-commandline.jar
+This should extract the file LanguageTool-5.1/languagetool-commandline.jar
 among several other files.
 
 ## Build LanguageTool from sources in git

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Recent versions of LanguageTool require Java-8.
 ## Download the stand-alone version of LanguageTool
 
 Download the stand-alone version of LanguageTool (LanguageTool-*.zip)
-from http://www.dev.languagetool.org/http-server.html/, scroll down and click on
+from https://dev.languagetool.org/http-server.html/, scroll down and click on
 "Desktop version for offline use" to download it. Unzip it:
 ```
   $ unzip LanguageTool-4.9.zip

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Recent versions of LanguageTool require Java-8.
 ## Download the stand-alone version of LanguageTool
 
 Download the stand-alone version of LanguageTool (LanguageTool-*.zip)
-from https://dev.languagetool.org/http-server.html/, scroll down and click on
+from https://dev.languagetool.org/http-server.html, scroll down and click on
 "Desktop version for offline use" to download it. Unzip it:
 ```
   $ unzip LanguageTool-4.9.zip

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ checker. You can chose to:
 
 * Download the stand-alone version of
   LanguageTool(LanguageTool-\*.zip) from
-  [here](http://www.languagetool.org/) using the orange button labeled
-  "LanguageTool for standalone for your desktop".
+  [here](https://dev.languagetool.org/http-server.html) using the 
+  first link labeled "Getting the server" at the top of the page.
 
 * or download a nightly build LanguageTool-.\*-snapshot.zip from
   http://www.languagetool.org/download/snapshots/. It contains a

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Recent versions of LanguageTool require Java-8.
 ## Download the stand-alone version of LanguageTool
 
 Download the stand-alone version of LanguageTool (LanguageTool-*.zip)
-from http://www.languagetool.org/, scroll down and click on
+from http://www.dev.languagetool.org/http-server.html/, scroll down and click on
 "Desktop version for offline use" to download it. Unzip it:
 ```
   $ unzip LanguageTool-4.9.zip


### PR DESCRIPTION
Updated standalone server download links.  There is no longer a link on the LanguageTool main web page you most go to there development site and from there you most navigate to there HTTP server page.