### PR TITLE
Fix typo in url to download LanguageTool

### DIFF
--- a/doc/LanguageTool.txt
+++ b/doc/LanguageTool.txt
@@ -101,7 +101,7 @@ Recent versions of LanguageTool require Java-8.
 4.2.1 Download the stand-alone version of LanguageTool~
 
 Download the latest stable stand-alone version of LanguageTool
-(file LanguageTool-*.zip) from http://www.languagetool.org/downloaad/ >
+(file LanguageTool-*.zip) from http://www.languagetool.org/download/ >
 
   $ wget https://languagetool.org/download/LanguageTool-5.2.zip
   $ unzip LanguageTool-5.2.zip


### PR DESCRIPTION
There is a small typo in `doc/LanguageTool.txt`. This PR fixes it. 