### PR TITLE
make window switching more robust to custom key bindings

### DIFF
--- a/autoload/languagetool.vim
+++ b/autoload/languagetool.vim
@@ -329,7 +329,7 @@ function languagetool#Check(line1, line2) "{{{1
     map <silent> <buffer> <CR> :call <sid>JumpToCurrentError()<CR>
     redraw
     echon 'Press <Enter> on error in scratch buffer to jump its location'
-    exe "norm! \<C-W>\<C-P>"
+    wincmd p
   else
     " Negative s:languagetool_win_height -> no scratch window.
     bd!


### PR DESCRIPTION
Apparently, the key used for `'pastetoggle'` is intercepted even in a `:normal!` command (!). For instance, if using `:set pastetoggle=<C-P>`, then `:exe "normal! \<C-W>\<C-P>` does not switch to the last window as expected. This was breaking the plugin for me, preventing error highlighting in the original window.

On the other hand, `:wincmd p` has the same effect and is apparently unaffected by `'pastetoggle'` or custom key bindings–and it is simpler.

There are other occurrences of `:norm!` that I left as is, as the implied key bindings (`$, G0, l, zz, z`) seem unlikely to be used for `'pastetoggle'`, and I’m not sure how to replace them.