### PR TITLE
Setting non version specific URL for download

### DIFF
--- a/doc/LanguageTool.txt
+++ b/doc/LanguageTool.txt
@@ -104,7 +104,7 @@ Download the latest stable stand-alone version of LanguageTool
 (file LanguageTool-*.zip) from http://www.languagetool.org/download/ >
 
   $ wget https://languagetool.org/download/LanguageTool-stable.zip
-  $ unzip LanguageTool-5.2.zip
+  $ unzip LanguageTool-stable.zip
 
 This should extract the file LanguageTool-5.2/languagetool-commandline.jar
 among several other files.

--- a/doc/LanguageTool.txt
+++ b/doc/LanguageTool.txt
@@ -103,7 +103,7 @@ Recent versions of LanguageTool require Java-8.
 Download the latest stable stand-alone version of LanguageTool
 (file LanguageTool-*.zip) from http://www.languagetool.org/download/ >
 
-  $ wget https://languagetool.org/download/LanguageTool-5.2.zip
+  $ wget https://languagetool.org/download/LanguageTool-stable.zip
   $ unzip LanguageTool-5.2.zip
 
 This should extract the file LanguageTool-5.2/languagetool-commandline.jar


### PR DESCRIPTION
It is correct to not have great expectations on the document, considering that new releases are available quite often. But this URL attends the current releases and is not specific.